### PR TITLE
rapidjson allocator for FreeRTOS

### DIFF
--- a/include/cereal/archives/json.hpp
+++ b/include/cereal/archives/json.hpp
@@ -426,7 +426,12 @@ namespace cereal
   {
     private:
       using ReadStream = CEREAL_RAPIDJSON_NAMESPACE::IStreamWrapper;
+#ifndef __freertos__
       typedef CEREAL_RAPIDJSON_NAMESPACE::GenericValue<CEREAL_RAPIDJSON_NAMESPACE::UTF8<>> JSONValue;
+#else
+      typedef CEREAL_RAPIDJSON_NAMESPACE::GenericValue<CEREAL_RAPIDJSON_NAMESPACE::UTF8<>,
+                                                       CEREAL_RAPIDJSON_NAMESPACE::MemoryPoolAllocator<CEREAL_RAPIDJSON_NAMESPACE::FrtosAllocator>> JSONValue;
+#endif
       typedef JSONValue::ConstMemberIterator MemberIterator;
       typedef JSONValue::ConstValueIterator ValueIterator;
       typedef CEREAL_RAPIDJSON_NAMESPACE::Document::GenericValue GenericValue;

--- a/include/cereal/external/rapidjson/document.h
+++ b/include/cereal/external/rapidjson/document.h
@@ -22,6 +22,9 @@
 #include "internal/strfunc.h"
 #include "memorystream.h"
 #include "encodedstream.h"
+#ifdef __freertos__
+#include "freertos_allocator.h"
+#endif
 #include <new>      // placement new
 #include <limits>
 
@@ -2107,7 +2110,11 @@ private:
 };
 
 //! GenericValue with UTF8 encoding
+#ifndef __freertos__
 typedef GenericValue<UTF8<> > Value;
+#else
+typedef GenericValue<UTF8<>, MemoryPoolAllocator<FrtosAllocator>> Value;
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 // GenericDocument
@@ -2503,7 +2510,11 @@ private:
 };
 
 //! GenericDocument with UTF8 encoding
+#ifndef __freertos__
 typedef GenericDocument<UTF8<> > Document;
+#else
+typedef GenericDocument<UTF8<>, MemoryPoolAllocator<FrtosAllocator>, FrtosAllocator> Document;
+#endif
 
 //! Helper class for accessing Value of array type.
 /*!

--- a/include/cereal/external/rapidjson/freertos_allocator.h
+++ b/include/cereal/external/rapidjson/freertos_allocator.h
@@ -1,0 +1,36 @@
+#ifndef FREERTOS_ALLOCATOR_H_
+#define FREERTOS_ALLOCATOR_H_
+
+CEREAL_RAPIDJSON_NAMESPACE_BEGIN
+
+class FrtosAllocator
+{
+public:
+    static const bool kNeedFree = true;
+    void *Malloc(size_t size)
+    {
+        if (size) //  behavior of malloc(0) is implementation defined.
+            return pvPortMalloc(size);
+        else
+            return NULL; // standardize to returning NULL.
+    }
+    void *Realloc(void *originalPtr, size_t originalSize, size_t newSize)
+    {
+        (void) originalSize;
+        if (newSize == 0) {
+            vPortFree(originalPtr);
+            return NULL;
+        }
+        void *newPtr = pvPortMalloc(newSize);
+        if (newPtr) {
+            memcpy(newPtr, originalPtr, originalSize);
+            vPortFree(originalPtr);
+        }
+        return newPtr;
+    }
+    static void Free(void *ptr) { vPortFree(ptr); }
+};
+
+CEREAL_RAPIDJSON_NAMESPACE_END
+
+#endif // FREERTOS_ALLOCATOR_H_


### PR DESCRIPTION
typedef Document, Value and JSONValue providing Allocator class, overriding default argument for type name, to avoid problems with long names in JSON name-value pairs ([https://github.com/Tencent/rapidjson/issues/1959](https://github.com/Tencent/rapidjson/issues/1959))
