### PR TITLE
Add missing include

### DIFF
--- a/include/cereal/external/rapidjson/freertos_allocator.h
+++ b/include/cereal/external/rapidjson/freertos_allocator.h
@@ -1,6 +1,8 @@
 #ifndef FREERTOS_ALLOCATOR_H_
 #define FREERTOS_ALLOCATOR_H_
 
+#include "FreeRTOS.h"
+
 CEREAL_RAPIDJSON_NAMESPACE_BEGIN
 
 class FrtosAllocator


### PR DESCRIPTION
This include is required for kpe-core to compile for ESP32